### PR TITLE
fix(tests): extend timeout for top-interacted analytics route tests

### DIFF
--- a/test-api/routes/analytics.routes.test.ts
+++ b/test-api/routes/analytics.routes.test.ts
@@ -191,7 +191,7 @@ describe('Analytics Routes', () => {
       expect(response.body).toHaveProperty('metrics');
       expect(response.body).toHaveProperty('aggregatedByInterval', 'daily');
       expect(response.body).toHaveProperty('limit', 3);
-    });
+    }, 15000); // 👈 agregado
 
     it('should return 400 with invalid query parameters', async () => {
       const response = await request(app)
@@ -244,7 +244,8 @@ describe('Analytics Routes', () => {
         expect(response.status).toBe(200);
         expect(response.body).toHaveProperty('aggregatedByInterval', range);
       }
-    });
+    }, 15000);
+
 
     it('should use default limit when not provided', async () => {
       const response = await request(app)
@@ -259,9 +260,10 @@ describe('Analytics Routes', () => {
           endDate: '2023-01-03'
         });
 
-      expect(response.status).toBe(200);
-      expect(response.body).toHaveProperty('limit', 3);
-    });
+        expect(response.status).toBe(200);
+        expect(response.body).toHaveProperty('limit', 3);
+    }, 15000);
+
 
     it('should handle date ranges spanning multiple periods', async () => {
       const response = await request(app)
@@ -278,7 +280,7 @@ describe('Analytics Routes', () => {
 
       expect(response.status).toBe(200);
       expect(response.body.metrics.length).toBeGreaterThan(1);
-    });
+    }, 15000);
 
     it('should return 403 for non-admin users', async () => {
       const response = await request(app)


### PR DESCRIPTION
- Increased timeout to 15s for tests involving /posts-stats/top-interacted to prevent failures in CI environments.
- Tests were previously exceeding Jest's default 5s limit due to data processing or network latency.
- All other analytics route tests remain unchanged and properly mocked.