### PR TITLE
Add overallTotal in total reports and posts

### DIFF
--- a/src/features/analytics/repositories/postStats.repository.ts
+++ b/src/features/analytics/repositories/postStats.repository.ts
@@ -44,3 +44,19 @@ export const getPostCountsByPeriod = async (
     count: Number(row.count),
   }));
 };
+
+export const getTotalPostsCount = async (): Promise<number> => {
+  try {
+    const query = `
+      SELECT COUNT(*) as total
+      FROM posts
+      WHERE is_active = true
+    `;
+    
+    const result = await client.query(query);
+    return parseInt(result.rows[0].total || '0');
+  } catch (error) {
+    console.error('Error fetching total posts count:', error);
+    throw new Error('Failed to retrieve total posts count');
+  }
+};

--- a/src/features/analytics/repositories/report-analytics.repository.interface.ts
+++ b/src/features/analytics/repositories/report-analytics.repository.interface.ts
@@ -3,4 +3,5 @@ import { DataPoint, TimeRangeQuery } from '../services/analytics-base.service';
 export interface IReportAnalyticsRepository {
   getReportVolumeData(params: TimeRangeQuery): Promise<DataPoint[]>;
   getTotalReports(startDate: string, endDate: string): Promise<number>;
+  getTotalOverallReports(): Promise<number>; 
 }

--- a/src/features/analytics/repositories/report-analytics.repository.ts
+++ b/src/features/analytics/repositories/report-analytics.repository.ts
@@ -70,4 +70,19 @@ export class ReportAnalyticsRepository implements IReportAnalyticsRepository {
       throw new InternalServerError('Failed to retrieve total reports count');
     }
   }
+
+  async getTotalOverallReports(): Promise<number> {
+    try {
+      const query = `
+        SELECT COUNT(*) as total
+        FROM reports
+      `;
+      
+      const result = await client.query(query);
+      return parseInt(result.rows[0].total || '0');
+    } catch (error) {
+      console.error('Error fetching total overall reports:', error);
+      throw new InternalServerError('Failed to retrieve total overall reports count');
+    }
+  }
 }

--- a/src/features/analytics/routes/analytics.routes.ts
+++ b/src/features/analytics/routes/analytics.routes.ts
@@ -19,7 +19,7 @@ router.get(
 );
 
 router.get(
-  '/posts-stats/volume',
+  '/reports-stats/volume',
   authenticateJWT,
   reportAnalyticsController.getReportVolumeStats.bind(reportAnalyticsController)
 );

--- a/src/features/analytics/services/postStats.service.ts
+++ b/src/features/analytics/services/postStats.service.ts
@@ -1,5 +1,5 @@
 import { StatsQueryDTO } from '../dto/postStats.dto';
-import { getPostCountsByPeriod } from '../repositories/postStats.repository';
+import { getPostCountsByPeriod, getTotalPostsCount } from '../repositories/postStats.repository';
 
 interface AnalyticsDataPoint {
   date: string;
@@ -11,6 +11,7 @@ interface PostStatsResponse {
   data: {
     series: AnalyticsDataPoint[];
     total: number;
+    overallTotal: number;
   };
 }
 
@@ -38,6 +39,8 @@ export const getTotalPostsStatsService = async (
 
   const total = data.reduce((sum, entry) => sum + entry.count, 0);
 
+   const overallTotal = await getTotalPostsCount();
+
   const sorted = data.sort((a, b) => {
     if (period === 'weekly') {
       return a.label.localeCompare(b.label);
@@ -57,6 +60,7 @@ export const getTotalPostsStatsService = async (
     data: {
       series,
       total,
+      overallTotal,
     },
   };
 };

--- a/src/features/analytics/services/report-analytics.service.ts
+++ b/src/features/analytics/services/report-analytics.service.ts
@@ -6,6 +6,7 @@ import { AnalyticsBaseService, DataPoint } from './analytics-base.service';
 interface ReportVolumeResponse {
   series: DataPoint[];
   total: number;
+  overallTotal: number;
   aggregatedByInterval: string;
 }
 
@@ -24,6 +25,9 @@ export class ReportAnalyticsService extends AnalyticsBaseService {
         query.startDate!,
         query.endDate!
       );
+
+      // Get the total count for all time (without date filters)
+      const overallTotal = await this.repository.getTotalOverallReports();
       
       // Get the report data grouped by interval
       const reportData = await this.repository.getReportVolumeData({
@@ -42,6 +46,7 @@ export class ReportAnalyticsService extends AnalyticsBaseService {
       return {
         series,
         total,
+        overallTotal,
         aggregatedByInterval: query.interval || 'daily'
       };
     } catch (error) {

--- a/test-api/integration/analytics.routes.test.ts
+++ b/test-api/integration/analytics.routes.test.ts
@@ -109,11 +109,14 @@ describe('Analytics Routes Integration Tests', () => {
     });
   });
 
-  describe('GET /api/analytics/posts-stats/volume', () => {
+  describe('GET /api/analytics/reports-stats/volume', () => {
     it('should return report volume statistics for authenticated admin', async () => {
       // Mock database responses
       (client.query as jest.Mock)
         .mockResolvedValueOnce({                                          // getTotalReports
+          rows: [{ total: '50' }]
+        })
+        .mockResolvedValueOnce({                                          // getTotalOverallReports
           rows: [{ total: '50' }]
         })
         .mockResolvedValueOnce({                                          // getReportVolumeData
@@ -124,7 +127,7 @@ describe('Analytics Routes Integration Tests', () => {
         });
 
       const response = await request(app)
-        .get('/api/analytics/posts-stats/volume')
+        .get('/api/analytics/reports-stats/volume')
         .set('Authorization', 'Bearer valid-token')
         .query({
           startDate: '2023-01-01',
@@ -141,6 +144,7 @@ describe('Analytics Routes Integration Tests', () => {
             { date: '2023-01-02', count: 15 }
           ],
           total: 50,
+          overallTotal: 50,
           aggregatedByInterval: 'daily'
         }
       });
@@ -154,7 +158,7 @@ describe('Analytics Routes Integration Tests', () => {
       }));
 
       const response = await request(app)
-        .get('/api/analytics/posts-stats/volume')
+        .get('/api/analytics/reports-stats/volume')
         .set('Authorization', 'Bearer valid-token');
 
       expect(response.status).toBe(403);
@@ -166,14 +170,14 @@ describe('Analytics Routes Integration Tests', () => {
 
     it('should return 401 for missing authentication', async () => {
       const response = await request(app)
-        .get('/api/analytics/posts-stats/volume');
+        .get('/api/analytics/reports-stats/volume');
 
       expect(response.status).toBe(401);
     });
 
     it('should return 400 for invalid query parameters', async () => {
       const response = await request(app)
-        .get('/api/analytics/posts-stats/volume')
+        .get('/api/analytics/reports-stats/volume')
         .set('Authorization', 'Bearer valid-token')
         .query({
           startDate: 'invalid-date',
@@ -193,7 +197,7 @@ describe('Analytics Routes Integration Tests', () => {
       (client.query as jest.Mock).mockRejectedValue(new Error('Database error'));
 
       const response = await request(app)
-        .get('/api/analytics/posts-stats/volume')
+        .get('/api/analytics/reports-stats/volume')
         .set('Authorization', 'Bearer valid-token')
         .query({
           startDate: '2023-01-01',


### PR DESCRIPTION
# Type of Change
[x] fix

## Description
This PR adds the overall total counts to both post and report analytics endpoints, providing total metrics regardless of date filters. It also fixes a route naming inconsistency.

## Changes

### 1. Added Overall Total Metrics
- Added `overallTotal` field to both post and report analytics responses
- Created `getTotalPostsCount()` method in post repository to fetch all-time counts
- Added `getTotalOverallReports()` method in report repository for all-time report counts

### 2. Fixed Route Naming
- Renamed route from `/posts-stats/volume` to `/reports-stats/volume` to correctly reflect its functionality
- This ensures API naming consistency and better represents the endpoint's actual purpose

### 3. Response Format Enhancement
- Both endpoints now return two totals:
  - `total`: Sum of items within the selected date range
  - `overallTotal`: Total count across all time periods

## Implementation Details
```typescript
// PostStats service enhancement
interface PostStatsResponse {
  message: string;
  data: {
    series: AnalyticsDataPoint[];
    total: number;
    overallTotal: number; // Added this field
  };
}

// Report analytics service enhancement
interface ReportVolumeResponse {
  series: DataPoint[];
  total: number;
  overallTotal: number; // Added this field
  aggregatedByInterval: string;
}
```

## Testing
- Verified both endpoints correctly display overall totals regardless of date filters
